### PR TITLE
feat: format PAW balances in templates

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -24,7 +24,7 @@
         <div class="balance-column">
           <ng-container *ngIf="(walletService.wallet.updatingBalance === false) else balanceLoading">
             <div class="balance primary">
-              {{ wallet.selectedAccount.balance | rai: 'nano,true' | amountsplit: 0 }}{{ wallet.selectedAccount.balance | rai: 'nano,true' | amountsplit: 1 }} PAW
+              {{ wallet.selectedAccount.balance | rai: 'nano,true' | amountsplit: 0 | number }}{{ wallet.selectedAccount.balance | rai: 'nano,true' | amountsplit: 1 }} PAW
             </div>
             <div class="balance converted">{{ wallet.selectedAccount.balanceFiat | fiat: settings.settings.displayCurrency }}</div>
           </ng-container>
@@ -42,7 +42,7 @@
         </div>
         <div class="balance-column">
           <ng-container *ngIf="(walletService.wallet.updatingBalance === false) else balanceLoading">
-            <div class="balance primary">{{ wallet.balance | rai: 'nano,true' | amountsplit: 0 }}{{ wallet.balance | rai: 'nano,true' | amountsplit: 1 }} PAW</div>
+            <div class="balance primary">{{ wallet.balance | rai: 'nano,true' | amountsplit: 0 | number }}{{ wallet.balance | rai: 'nano,true' | amountsplit: 1 }} PAW</div>
             <div class="balance converted">{{ wallet.balanceFiat | fiat: settings.settings.displayCurrency }}</div>
           </ng-container>
           <ng-template #balanceLoading>
@@ -63,9 +63,9 @@
               <div class="balance primary">
                 <span class="incoming-label" *ngIf="account.pending.gt(0)">
                   <span class="text-snippet">{{ 'general.new' | transloco }}</span>
-                  <span class="text-full">+{{ account.pending | rai: 'nano,true' | amountsplit: 0 }}{{ account.pending | rai: 'nano,true' | amountsplit: 1 }} PAW</span>
+                  <span class="text-full">+{{ account.pending | rai: 'nano,true' | amountsplit: 0 | number }}{{ account.pending | rai: 'nano,true' | amountsplit: 1 }} PAW</span>
                 </span>
-                {{ account.balance | rai: 'nano,true' | amountsplit: 0 }}{{ account.balance | rai: 'nano,true' | amountsplit: 1 }} PAW
+                {{ account.balance | rai: 'nano,true' | amountsplit: 0 | number }}{{ account.balance | rai: 'nano,true' | amountsplit: 1 }} PAW
               </div>
               <div class="balance converted">{{ account.balanceFiat | fiat: settings.settings.displayCurrency }}</div>
             </ng-container>
@@ -126,7 +126,7 @@
                       <div class="balance-container primary">
                         <div class="currency-name">PAW</div>
                         <div class="amount-container">
-                          <div class="amount-integer">{{ (wallet.selectedAccount !== null ? wallet.selectedAccount.balance : wallet.balance) | rai: 'nano,true' | amountsplit: 0 }}</div>
+                          <div class="amount-integer">{{ (wallet.selectedAccount !== null ? wallet.selectedAccount.balance : wallet.balance) | rai: 'nano,true' | amountsplit: 0 | number }}</div>
                           <div class="amount-fractional">{{ (wallet.selectedAccount !== null ? wallet.selectedAccount.balance : wallet.balance) | rai: 'nano,true' | amountsplit: 1 }}</div>
                           <div class="amount-updating" *ngIf="wallet.updatingBalance && isConfigured()"><div uk-spinner="ratio: 0.5;"></div></div>
                         </div>
@@ -134,7 +134,7 @@
                       <div class="balance-container converted" *ngIf="settings.settings.displayCurrency">
                         <div class="currency-name"><span class="estimate-symbol">~</span>{{ settings.settings.displayCurrency }}</div>
                         <div class="amount-container">
-                          <div class="amount-integer">{{ (wallet.selectedAccount !== null ? wallet.selectedAccount.balanceFiat : wallet.balanceFiat) | fiat: settings.settings.displayCurrency | amountsplit: 0 }}</div>
+                          <div class="amount-integer">{{ (wallet.selectedAccount !== null ? wallet.selectedAccount.balanceFiat : wallet.balanceFiat) | fiat: settings.settings.displayCurrency | amountsplit: 0 | number }}</div>
                           <div class="amount-fractional">{{ (wallet.selectedAccount !== null ? wallet.selectedAccount.balanceFiat : wallet.balanceFiat) | fiat: settings.settings.displayCurrency | amountsplit: 1 }}</div>
                         </div>
                       </div>
@@ -178,14 +178,14 @@
                       <div class="balance-container primary">
                         <div class="currency-name">PAW</div>
                         <div class="amount-container">
-                          <div class="amount-integer">{{ (wallet.selectedAccount ? wallet.selectedAccount.pending : wallet.pending) | rai: 'nano,true' | amountsplit: 0 }}</div>
+                          <div class="amount-integer">{{ (wallet.selectedAccount ? wallet.selectedAccount.pending : wallet.pending) | rai: 'nano,true' | amountsplit: 0 | number }}</div>
                           <div class="amount-fractional">{{ (wallet.selectedAccount ? wallet.selectedAccount.pending : wallet.pending) | rai: 'nano,true' | amountsplit: 1 }}</div>
                         </div>
                       </div>
                       <div class="balance-container converted" *ngIf="settings.settings.displayCurrency">
                         <div class="currency-name"><span class="estimate-symbol">~</span>{{ settings.settings.displayCurrency }}</div>
                         <div class="amount-container">
-                          <div class="amount-integer">{{ (wallet.selectedAccount ? wallet.selectedAccount.pendingFiat : wallet.pendingFiat) | fiat: settings.settings.displayCurrency | amountsplit: 0 }}</div>
+                          <div class="amount-integer">{{ (wallet.selectedAccount ? wallet.selectedAccount.pendingFiat : wallet.pendingFiat) | fiat: settings.settings.displayCurrency | amountsplit: 0 | number }}</div>
                           <div class="amount-fractional">{{ (wallet.selectedAccount ? wallet.selectedAccount.pendingFiat : wallet.pendingFiat) | fiat: settings.settings.displayCurrency | amountsplit: 1 }}</div>
                         </div>
                       </div>

--- a/src/app/components/account-details/account-details.component.html
+++ b/src/app/components/account-details/account-details.component.html
@@ -24,7 +24,7 @@
             <div class="balance-container primary">
               <div class="currency-name">PAW</div>
               <div class="amount-container">
-                <div class="amount-integer">{{ !account ? 0 : (account.balance || 0 | rai: 'nano,true') | amountsplit: 0 }}</div>
+                <div class="amount-integer">{{ !account ? 0 : (account.balance || 0 | rai: 'nano,true') | amountsplit: 0 | number }}</div>
                 <div class="amount-fractional">{{ !account ? 0 : (account.balance || 0 | rai: 'nano,true') | amountsplit: 1 }}</div>
                 <div class="amount-updating" *ngIf="wallet.updatingBalance && isConfigured()"><div uk-spinner="ratio: 0.5;"></div></div>
               </div>
@@ -32,7 +32,7 @@
             <div class="balance-container converted" *ngIf="settings.settings.displayCurrency">
               <div class="currency-name"><span class="estimate-symbol">~</span>{{ settings.settings.displayCurrency }}</div>
               <div class="amount-container">
-                <div class="amount-integer">{{ (account.balanceFiat | fiat: settings.settings.displayCurrency) | amountsplit: 0 }}</div>
+                <div class="amount-integer">{{ (account.balanceFiat | fiat: settings.settings.displayCurrency) | amountsplit: 0 | number }}</div>
                 <div class="amount-fractional">{{ (account.balanceFiat | fiat: settings.settings.displayCurrency) | amountsplit: 1 }}</div>
               </div>
             </div>
@@ -175,7 +175,7 @@
                     class="account-amounts-primary-confirmed"
                     [title]="( (account && account.balanceRaw && account.balanceRaw.gt(0) ) ? ( '+' + ( account.balanceRaw.toString(10)  ) + ' raw' ) : '' )"
                   >
-                    <span class="amount-integer">{{ !account ? 0 : (account.balance || 0 | rai: 'nano,true') | amountsplit: 0 }}</span>
+                    <span class="amount-integer">{{ !account ? 0 : (account.balance || 0 | rai: 'nano,true') | amountsplit: 0 | number }}</span>
                     <span class="amount-fractional">{{ !account ? 0 : (account.balance || 0 | rai: 'nano,true') | amountsplit: 1 }}</span>
                     <span class="amount-currency-name">PAW</span>
                   </div>
@@ -187,7 +187,7 @@
                     <div class="text-snippet">{{ 'general.new' | transloco }}</div>
                     <div class="text-full">
                       <div class="amount-sign">+</div>
-                      <div class="amount-integer">{{ account.pending | rai: 'nano,true' | amountsplit: 0 }}</div>
+                      <div class="amount-integer">{{ account.pending | rai: 'nano,true' | amountsplit: 0 | number }}</div>
                       <div class="amount-fractional">{{ account.pending | rai: 'nano,true' | amountsplit: 1 }}</div>
                       <div class="amount-currency-name">PAW</div>
                     </div>
@@ -386,7 +386,7 @@
           </ng-template>
           <td class="amount-column uk-text-middle uk-text-muted" [title]="('Incoming Transaction') + ( (pending.amountRaw && (pending.amountRaw > 0) ) ? ( ', +' + ( pending.amountRaw.toString(10) ) + ' raw' ) : '' )">
             <span class="uk-text-small">{{ 'general.actions.ready-to-receive' | transloco }}</span><br>
-            <span class="amount-integer">{{ pending.amount | rai: 'nano,true' | amountsplit: 0 }}</span>
+            <span class="amount-integer">{{ pending.amount | rai: 'nano,true' | amountsplit: 0 | number }}</span>
             <span class="amount-fractional">{{ pending.amount | rai: 'nano,true' | amountsplit: 1 }}</span>
             <span class="currency-name">PAW</span>
             <div class="compact-actions-date">
@@ -482,7 +482,7 @@
                   <span class="icon-unconfirmed" uk-icon="icon: clock;" *ngIf="(history.confirmed === false)"></span>
                 </span><br>
               </ng-container>
-              <span class="amount-integer">{{ history.amount | rai: 'nano,true' | amountsplit: 0 }}</span>
+              <span class="amount-integer">{{ history.amount | rai: 'nano,true' | amountsplit: 0 | number }}</span>
               <span class="amount-fractional">{{ history.amount | rai: 'nano,true' | amountsplit: 1 }}</span>
               <span class="currency-name">PAW</span>
               <div class="compact-actions-date text-half-muted">

--- a/src/app/components/accounts/accounts.component.html
+++ b/src/app/components/accounts/accounts.component.html
@@ -47,10 +47,10 @@
               <div class="account-amounts-primary uk-width-1-1">
                 <div *ngIf="account.pending.gt(0)" class="incoming-label">
                   <div class="text-snippet">{{ 'general.new' | transloco }}</div>
-                  <div class="text-full">+{{ account.pending | rai: 'nano,true' | amountsplit: 0 }}{{ account.pending | rai: 'nano,true' | amountsplit: 1 }} PAW</div>
+                  <div class="text-full">+{{ account.pending | rai: 'nano,true' | amountsplit: 0 | number }}{{ account.pending | rai: 'nano,true' | amountsplit: 1 }} PAW</div>
                 </div>
                 <span class="amounts" [title]="( account.balanceRaw.gt(0) ? ( '+' + ( account.balanceRaw.toString(10) ) + ' raw' ) : '' )">
-                  <span class="amount-integer">{{ account.balance | rai: 'nano,true' | amountsplit: 0 }}</span>
+                  <span class="amount-integer">{{ account.balance | rai: 'nano,true' | amountsplit: 0 | number }}</span>
                   <span class="amount-fractional">{{ account.balance | rai: 'nano,true' | amountsplit: 1 }}</span>
                   <span class="currency-name">PAW</span>
                 </span>

--- a/src/app/components/address-book/address-book.component.html
+++ b/src/app/components/address-book/address-book.component.html
@@ -26,13 +26,13 @@
 
         <div class="advanced-options" *ngIf="showAdvancedOptions">
           <span [title]="( totalTrackedBalanceRaw.gt(0) ? ( '+' + ( totalTrackedBalanceRaw.toString(10) ) + ' raw' ) : '' )">
-            <span class="amount-integer">{{ totalTrackedBalance | rai: 'nano,true' | amountsplit: 0 }}</span>
+            <span class="amount-integer">{{ totalTrackedBalance | rai: 'nano,true' | amountsplit: 0 | number }}</span>
             <span class="amount-fractional">{{ totalTrackedBalance | rai: 'nano,true' | amountsplit: 1 }}</span>
             <span class="currency-name">PAW</span>
           </span>
           <div *ngIf="totalTrackedPending.gt(0)" class="incoming-label">
             <div class="text-snippet">New</div>
-            <div class="text-full">+{{ totalTrackedPending | rai: 'nano,true' | amountsplit: 0 }}{{ totalTrackedPending | rai: 'nano,true' | amountsplit: 1 }} PAW</div>
+            <div class="text-full">+{{ totalTrackedPending | rai: 'nano,true' | amountsplit: 0 | number }}{{ totalTrackedPending | rai: 'nano,true' | amountsplit: 1 }} PAW</div>
           </div>
           <div class="account-amounts-converted uk-width-1-1 text-half-muted">
             {{ totalTrackedBalanceFiat | fiat: appSettings.settings.displayCurrency }}
@@ -107,13 +107,13 @@
                       <ng-container *ngIf="(walletService.wallet.updatingBalance === false) else balanceLoading">
                         <div class="account-amounts-primary uk-width-1-1">
                           <span [title]="( accounts[addressBook.account]?.balanceRaw.gt(0) ? ( '+' + ( accounts[addressBook.account]?.balanceRaw.toString(10) ) + ' raw' ) : '' )">
-                            <span class="amount-integer">{{ accounts[addressBook.account]?.balance | rai: 'nano,true' | amountsplit: 0 }}</span>
+                            <span class="amount-integer">{{ accounts[addressBook.account]?.balance | rai: 'nano,true' | amountsplit: 0 | number }}</span>
                             <span class="amount-fractional">{{ accounts[addressBook.account]?.balance | rai: 'nano,true' | amountsplit: 1 }}</span>
                             <span class="currency-name">PAW</span>
                           </span>
                           <div *ngIf="accounts[addressBook.account]?.pending.gt(0)" class="incoming-label">
                             <div class="text-snippet">New</div>
-                            <div class="text-full">+{{ accounts[addressBook.account]?.pending | rai: 'nano,true' | amountsplit: 0 }}{{ accounts[addressBook.account]?.pending | rai: 'nano,true' | amountsplit: 1 }} PAW</div>
+                            <div class="text-full">+{{ accounts[addressBook.account]?.pending | rai: 'nano,true' | amountsplit: 0 | number }}{{ accounts[addressBook.account]?.pending | rai: 'nano,true' | amountsplit: 1 }} PAW</div>
                           </div>
                         </div>
                         <div class="account-amounts-converted uk-width-1-1 text-half-muted">

--- a/src/app/components/helpers/nano-transaction-mobile/nano-transaction-mobile.component.html
+++ b/src/app/components/helpers/nano-transaction-mobile/nano-transaction-mobile.component.html
@@ -119,7 +119,7 @@
 			>{{ 'general.actions.unknown-action' | transloco }}<ng-template [ngTemplateOutlet]="unconfirmedIcon"></ng-template></div>
 		</ng-container>
 		<div class="amount" *ngIf="isReceivableTransaction || isSendTransaction || isReceiveTransaction">
-			<span class="amount-integer">{{ transaction.amount | rai: 'nano,true' | amountsplit: 0 }}</span>
+			<span class="amount-integer">{{ transaction.amount | rai: 'nano,true' | amountsplit: 0 | number }}</span>
 			<span class="amount-fractional">{{ transaction.amount | rai: 'nano,true' | amountsplit: 1 }}</span>
 			<span class="currency-name">PAW</span>
 		</div>

--- a/src/app/components/manage-wallet/manage-wallet.component.html
+++ b/src/app/components/manage-wallet/manage-wallet.component.html
@@ -130,7 +130,7 @@
                 <label class="uk-form-label" for="account">Account</label>
                 <div class="uk-form-controls">
                   <select class="uk-select" id="account" [(ngModel)]="csvAccount">
-                    <option *ngFor="let account of accounts" [value]="account.id">{{account.addressBookName ? account.addressBookName + ' - ' : '#' + account.index + ' - ' }} {{ account.id | squeeze }} ({{ account.balance | rai: 'nano,true' | amountsplit: 0 }}{{ account.balance | rai: 'nano,true' | amountsplit: 1 }} PAW)</option>
+                    <option *ngFor="let account of accounts" [value]="account.id">{{account.addressBookName ? account.addressBookName + ' - ' : '#' + account.index + ' - ' }} {{ account.id | squeeze }} ({{ account.balance | rai: 'nano,true' | amountsplit: 0 | number }}{{ account.balance | rai: 'nano,true' | amountsplit: 1 }} PAW)</option>
                   </select>
                 </div>
               </div>

--- a/src/app/components/receive/receive.component.html
+++ b/src/app/components/receive/receive.component.html
@@ -13,7 +13,7 @@
               <div class="form-account">
                 <select id="form-horizontal-select" class="uk-select" [(ngModel)]="pendingAccountModel" (change)="onSelectedAccountChange(pendingAccountModel)">
                   <option [value]="0">All Accounts</option>
-                  <option *ngFor="let account of accounts" [value]="account.id">{{account.addressBookName ? account.addressBookName + ' - ' : '#' + account.index + ' - ' }} {{ account.id | squeeze }} ({{ account.balance | rai: 'nano,true' | amountsplit: 0 }}{{ account.balance | rai: 'nano,true' | amountsplit: 1 }} PAW)</option>
+                  <option *ngFor="let account of accounts" [value]="account.id">{{account.addressBookName ? account.addressBookName + ' - ' : '#' + account.index + ' - ' }} {{ account.id | squeeze }} ({{ account.balance | rai: 'nano,true' | amountsplit: 0 | number }}{{ account.balance | rai: 'nano,true' | amountsplit: 1 }} PAW)</option>
                 </select>
               </div>
             </div>
@@ -200,7 +200,7 @@
             </ng-template>
             <td class="amount-column uk-text-middle uk-text-muted" [title]="('Incoming Transaction') + ( (pending.amountRaw && (pending.amountRaw > 0) ) ? ( ', +' + ( pending.amountRaw.toString(10) ) + ' raw' ) : '' )">
               <span class="uk-text-small">Ready to receive</span><br>
-              <span class="amount-integer">{{ pending.amount | rai: 'nano,true' | amountsplit: 0 }}</span>
+              <span class="amount-integer">{{ pending.amount | rai: 'nano,true' | amountsplit: 0 | number }}</span>
               <span class="amount-fractional">{{ pending.amount | rai: 'nano,true' | amountsplit: 1 }}</span>
               <span class="currency-name">PAW</span>
               <div class="compact-actions-date">
@@ -226,7 +226,7 @@
         <table class="uk-table uk-table-striped uk-table-small" *ngIf="settings.settings.minimumReceive">
           <thead>
             <tr class="uk-alert uk-alert-primary missing-accounts-hint">
-              <td colspan="4" style="text-align: center;"><span uk-icon="icon: info"></span> Minimum Receive is set to <a class="hint-action" routerLink="/configure-app" routerLinkActive="active" *ngIf="( util.nano.nanoToRaw(this.settings.settings.minimumReceive).toFixed().length > 24 ) else amountInRaw">{{ util.nano.nanoToRaw(this.settings.settings.minimumReceive).toFixed() | rai: 'nano,true' | amountsplit: 0 }}{{ util.nano.nanoToRaw(this.settings.settings.minimumReceive).toFixed() | rai: 'nano,true' | amountsplit: 1 }} PAW</a><ng-template #amountInRaw><a class="hint-action" routerLink="/configure-app" routerLinkActive="active">{{ util.nano.nanoToRaw(this.settings.settings.minimumReceive).toFixed() }} raw</a></ng-template>, transactions below this amount will be hidden.</td>
+              <td colspan="4" style="text-align: center;"><span uk-icon="icon: info"></span> Minimum Receive is set to <a class="hint-action" routerLink="/configure-app" routerLinkActive="active" *ngIf="( util.nano.nanoToRaw(this.settings.settings.minimumReceive).toFixed().length > 24 ) else amountInRaw">{{ util.nano.nanoToRaw(this.settings.settings.minimumReceive).toFixed() | rai: 'nano,true' | amountsplit: 0 | number }}{{ util.nano.nanoToRaw(this.settings.settings.minimumReceive).toFixed() | rai: 'nano,true' | amountsplit: 1 }} PAW</a><ng-template #amountInRaw><a class="hint-action" routerLink="/configure-app" routerLinkActive="active">{{ util.nano.nanoToRaw(this.settings.settings.minimumReceive).toFixed() }} raw</a></ng-template>, transactions below this amount will be hidden.</td>
             </tr>
           </thead>
         </table>

--- a/src/app/components/representatives/representatives.component.html
+++ b/src/app/components/representatives/representatives.component.html
@@ -72,7 +72,7 @@
                   <td class="voting-weight-column uk-width-1-4">
                     <div class="uk-text-small text-half-muted">Total</div>
                     <div class="amounts">
-                      <span class="amount-integer">{{ rep.delegatedWeight | rai: 'nano,true' | amountsplit: 0 }}</span>
+                      <span class="amount-integer">{{ rep.delegatedWeight | rai: 'nano,true' | amountsplit: 0 | number }}</span>
                       <span class="amount-fractional">{{ rep.delegatedWeight | rai: 'nano,true' | amountsplit: 1 }}</span>
                       <span class="currency-name">PAW</span>
                     </div>
@@ -95,7 +95,7 @@
                   </td>
                   <td class="voting-weight-column uk-width-1-4">
                     <div class="amounts">
-                      <span class="amount-integer">{{ delegatingAccount.balance | rai: 'nano,true' | amountsplit: 0 }}</span>
+                      <span class="amount-integer">{{ delegatingAccount.balance | rai: 'nano,true' | amountsplit: 0 | number }}</span>
                       <span class="amount-fractional">{{ delegatingAccount.balance | rai: 'nano,true' | amountsplit: 1 }}</span>
                       <span class="currency-name">PAW</span>
                     </div>
@@ -136,7 +136,7 @@
                   <select class="uk-select" [(ngModel)]="changeAccountID" (change)="newAccountID()" id="form-horizontal-select">
                     <option [value]="null">Select Accounts to Change</option>
                     <option [value]="'all'">All Current Accounts</option>
-                    <option *ngFor="let account of walletService.wallet.accounts" [value]="account.id">{{account.addressBookName ? account.addressBookName + ' - ' : '#' + account.index + ' - ' }} {{ account.id | squeeze }} ({{ account.balance | rai: 'nano,true' | amountsplit: 0 }}{{ account.balance | rai: 'nano,true' | amountsplit: 1 }} PAW)</option>
+                    <option *ngFor="let account of walletService.wallet.accounts" [value]="account.id">{{account.addressBookName ? account.addressBookName + ' - ' : '#' + account.index + ' - ' }} {{ account.id | squeeze }} ({{ account.balance | rai: 'nano,true' | amountsplit: 0 | number }}{{ account.balance | rai: 'nano,true' | amountsplit: 1 }} PAW)</option>
                   </select>
                   <ul class="uk-list uk-list-striped">
                     <li *ngFor="let account of selectedAccounts">

--- a/src/app/components/send/send.component.html
+++ b/src/app/components/send/send.component.html
@@ -22,7 +22,7 @@
                 <label class="uk-form-label" for="form-horizontal-select">From Account</label>
                 <div class="uk-form-controls">
                   <select class="form-select-source uk-select" [(ngModel)]="fromAccountID" (change)="resetRaw()" id="form-horizontal-select">
-                    <option *ngFor="let account of accounts" [value]="account.id">{{account.addressBookName ? account.addressBookName + ' - ' : '#' + account.index + ' - ' }} {{ account.id | squeeze }} ({{ account.balance | rai: 'nano,true' | amountsplit: 0 }}{{ account.balance | rai: 'nano,true' | amountsplit: 1 }} PAW)</option>
+                    <option *ngFor="let account of accounts" [value]="account.id">{{account.addressBookName ? account.addressBookName + ' - ' : '#' + account.index + ' - ' }} {{ account.id | squeeze }} ({{ account.balance | rai: 'nano,true' | amountsplit: 0 | number }}{{ account.balance | rai: 'nano,true' | amountsplit: 1 }} PAW)</option>
                   </select>
                 </div>
               </div>
@@ -59,7 +59,7 @@
                   <select required class="form-select-destination uk-select" [(ngModel)]="toOwnAccountID" id="form-horizontal-select">
                     <option value="" disabled selected hidden>Account to transfer to</option>
                     <ng-container *ngFor="let account of accounts">
-                      <option [value]="account.id" *ngIf="account.id !== fromAccountID">{{account.addressBookName ? account.addressBookName + ' - ' : '#' + account.index + ' - ' }} {{ account.id | squeeze }} ({{ account.balance | rai: 'nano,true' | amountsplit: 0 }}{{ account.balance | rai: 'nano,true' | amountsplit: 1 }} PAW)</option>
+                      <option [value]="account.id" *ngIf="account.id !== fromAccountID">{{account.addressBookName ? account.addressBookName + ' - ' : '#' + account.index + ' - ' }} {{ account.id | squeeze }} ({{ account.balance | rai: 'nano,true' | amountsplit: 0 | number }}{{ account.balance | rai: 'nano,true' | amountsplit: 1 }} PAW)</option>
                     </ng-container>
                   </select>
                 </div>
@@ -130,7 +130,7 @@
           <div class="uk-card-body" style="padding: 15px;">
             <div class="uk-text-danger">You are about to send</div>
             <div class="block-amount-primary uk-text-danger">
-              <span class="amount-integer">{{ rawAmount | rai: 'nano,true' | amountsplit: 0 }}</span>
+              <span class="amount-integer">{{ rawAmount | rai: 'nano,true' | amountsplit: 0 | number }}</span>
               <span class="amount-fractional">{{ rawAmount | rai: 'nano,true' | amountsplit: 1 }}</span>
               <span class="currency-name">PAW</span>
             </div>
@@ -166,7 +166,7 @@
                     <div class="uk-text-small text-half-muted" style="height: 25px;">Current Balance</div>
                     <span class="block-balance">
                       <span class="balance-amount-primary">
-                        <span class="amount-integer">{{ (fromAccount.balance || 0) | rai: 'nano,true' | amountsplit: 0 }}</span>
+                        <span class="amount-integer">{{ (fromAccount.balance || 0) | rai: 'nano,true' | amountsplit: 0 | number }}</span>
                         <span class="amount-fractional">{{ (fromAccount.balance || 0) | rai: 'nano,true' | amountsplit: 1 }}</span>
                         <span class="currency-name">PAW</span>
                       </span>
@@ -177,7 +177,7 @@
                     <span class="block-balance">
                       <span class="balance-amount-primary uk-text-danger">
                         <span class="amount-sign">-</span>
-                        <span class="amount-integer">{{ rawAmount | rai: 'nano,true' | amountsplit: 0 }}</span>
+                        <span class="amount-integer">{{ rawAmount | rai: 'nano,true' | amountsplit: 0 | number }}</span>
                         <span class="amount-fractional">{{ rawAmount | rai: 'nano,true' | amountsplit: 1 }}</span>
                         <span class="currency-name">PAW</span>
                       </span>
@@ -213,7 +213,7 @@
                     <div class="uk-text-small text-half-muted" style="height: 25px;">Current Balance</div>
                     <span class="block-balance">
                       <span class="balance-amount-primary">
-                        <span class="amount-integer">{{ (toAccount.balance || 0) | rai: 'nano,true' | amountsplit: 0 }}</span>
+                        <span class="amount-integer">{{ (toAccount.balance || 0) | rai: 'nano,true' | amountsplit: 0 | number }}</span>
                         <span class="amount-fractional">{{ (toAccount.balance || 0) | rai: 'nano,true' | amountsplit: 1 }}</span>
                         <span class="currency-name">PAW</span>
                       </span>
@@ -224,7 +224,7 @@
                     <span class="block-balance">
                       <span class="balance-amount-primary uk-text-success">
                         <span class="amount-sign">+</span>
-                        <span class="amount-integer">{{ rawAmount | rai: 'nano,true' | amountsplit: 0 }}</span>
+                        <span class="amount-integer">{{ rawAmount | rai: 'nano,true' | amountsplit: 0 | number }}</span>
                         <span class="amount-fractional">{{ rawAmount | rai: 'nano,true' | amountsplit: 1 }}</span>
                         <span class="currency-name">PAW</span>
                       </span>

--- a/src/app/components/sign/sign.component.html
+++ b/src/app/components/sign/sign.component.html
@@ -18,7 +18,7 @@
 
             <div *ngIf="txType != txTypes.change">
               <div class="block-amount-primary" [class.uk-text-danger]="txType == txTypes.send" [class.uk-text-success]="txType == txTypes.receive">
-                <span class="amount-integer">{{ rawAmount | rai: 'nano,true' | amountsplit: 0 }}</span>
+                <span class="amount-integer">{{ rawAmount | rai: 'nano,true' | amountsplit: 0 | number }}</span>
                 <span class="amount-fractional">{{ rawAmount | rai: 'nano,true' | amountsplit: 1 }}</span>
                 <span class="currency-name">PAW</span>
               </div>
@@ -66,7 +66,7 @@
                     <span class="block-balance">
                       <span class="balance-amount-primary uk-text-danger">
                         <span class="amount-sign">-</span>
-                        <span class="amount-integer">{{ rawAmount | rai: 'nano,true' | amountsplit: 0 }}</span>
+                        <span class="amount-integer">{{ rawAmount | rai: 'nano,true' | amountsplit: 0 | number }}</span>
                         <span class="amount-fractional">{{ rawAmount | rai: 'nano,true' | amountsplit: 1 }}</span>
                         <span class="currency-name">PAW</span>
                       </span>
@@ -128,7 +128,7 @@
                     <span class="block-balance">
                       <span class="balance-amount-primary uk-text-success">
                         <span class="amount-sign">+</span>
-                        <span class="amount-integer">{{ rawAmount | rai: 'nano,true' | amountsplit: 0 }}</span>
+                        <span class="amount-integer">{{ rawAmount | rai: 'nano,true' | amountsplit: 0 | number }}</span>
                         <span class="amount-fractional">{{ rawAmount | rai: 'nano,true' | amountsplit: 1 }}</span>
                         <span class="currency-name">PAW</span>
                       </span>

--- a/src/app/components/sweeper/sweeper.component.html
+++ b/src/app/components/sweeper/sweeper.component.html
@@ -44,7 +44,7 @@
                 <label class="uk-form-label" for="destination-account">Local Destination <span uk-icon="icon: info;" uk-tooltip title="Local accounts that can be used as destination for the swept funds. Make sure you are able to unlock your Biome wallet."></span></label>
                 <div class="uk-form-controls">
                   <select class="uk-select" id="destination-account" [(ngModel)]="myAccountModel" (change)="setDestination(myAccountModel)">
-                    <option *ngFor="let account of accounts" [value]="account.id">{{account.addressBookName ? account.addressBookName + ' - ' : '#' + account.index + ' - ' }} {{ account.id | squeeze }} ({{ account.balance | rai: 'nano,true' | amountsplit: 0 }}{{ account.balance | rai: 'nano,true' | amountsplit: 1 }} PAW)</option>
+                    <option *ngFor="let account of accounts" [value]="account.id">{{account.addressBookName ? account.addressBookName + ' - ' : '#' + account.index + ' - ' }} {{ account.id | squeeze }} ({{ account.balance | rai: 'nano,true' | amountsplit: 0 | number }}{{ account.balance | rai: 'nano,true' | amountsplit: 1 }} PAW)</option>
                     <option [value]="0">Custom Destination</option>
                   </select>
                 </div>

--- a/src/app/components/transaction-details/transaction-details.component.html
+++ b/src/app/components/transaction-details/transaction-details.component.html
@@ -47,7 +47,7 @@
             [class.uk-text-danger]="(blockType === 'send')"
             [class.uk-text-success]="( (blockType === 'open') || (blockType === 'receive') )"
           >
-            <span class="amount-integer">{{ transaction?.amount | rai: 'nano,true' | amountsplit: 0 }}</span>
+            <span class="amount-integer">{{ transaction?.amount | rai: 'nano,true' | amountsplit: 0 | number }}</span>
             <span class="amount-fractional">{{ transaction?.amount | rai: 'nano,true' | amountsplit: 1 }}</span>
             <span class="currency-name">PAW</span>
           </div>
@@ -155,7 +155,7 @@
           <label class="uk-form-label">Balance:</label>
           <div class="uk-form-controls uk-text-truncate block-balance">
             <div class="balance-amount-primary uk-text-truncate">
-              <span class="amount-integer">{{ ( isStateBlock ? getBalanceFromDec(transaction?.contents?.balance) : getBalanceFromHex(transaction?.contents?.balance )) | rai: 'nano,true' | amountsplit: 0 }}</span>
+              <span class="amount-integer">{{ ( isStateBlock ? getBalanceFromDec(transaction?.contents?.balance) : getBalanceFromHex(transaction?.contents?.balance )) | rai: 'nano,true' | amountsplit: 0 | number }}</span>
               <span class="amount-fractional">{{ ( isStateBlock ? getBalanceFromDec(transaction?.contents?.balance) : getBalanceFromHex(transaction?.contents?.balance )) | rai: 'nano,true' | amountsplit: 1 }}</span>
               <span class="currency-name">PAW</span>
             </div>


### PR DESCRIPTION
The integer part of PAW balances is passed through Angular's existing number pipe before being displayed.

Inputs fields and outputs in Raw are not included in this change.

Some samples of what that looks like (default locale) in different parts of the app:
![send screen](https://user-images.githubusercontent.com/17671117/147752374-267127c8-919e-4a69-9b57-403dffd99d1f.png)
![received transactions](https://user-images.githubusercontent.com/17671117/147752376-4f71bb74-8a81-4ef7-9812-7c980c9f6ade.png)
![sidebar](https://user-images.githubusercontent.com/17671117/147751611-ae63fd98-1d29-4f28-805a-bf310bfc9a99.png)
![accounts list](https://user-images.githubusercontent.com/17671117/147751613-d09cd961-af8a-409c-8d2a-d573ddad03cf.png)
![tribes](https://user-images.githubusercontent.com/17671117/147751615-58542422-fabe-4c29-9ccd-341d54974748.png)
![sidebar account list](https://user-images.githubusercontent.com/17671117/147751617-da0d820e-7d93-459c-bc21-9a5dec99c32c.png)
