### PR TITLE
fix: update total supply from nano to paw

### DIFF
--- a/src/app/components/representatives/representatives.component.ts
+++ b/src/app/components/representatives/representatives.component.ts
@@ -228,7 +228,7 @@ export class RepresentativesComponent implements OnInit {
     this.recommendedRepsLoading = true;
     try {
       const scores = await this.ninja.recommended() as any[];
-      const totalSupply = new BigNumber(133248289);
+      const totalSupply = new BigNumber("340282366920938463463374607431768211455").shift(-27);
 
       const reps = scores.map(rep => {
         const nanoWeight = this.util.nano.rawToNano(rep.votingweight.toString() || 0);
@@ -236,7 +236,7 @@ export class RepresentativesComponent implements OnInit {
 
         // rep.weight = nanoWeight.toString(10);
         rep.weight = this.util.nano.rawToNano(nanoWeight);
-        rep.percent = percent.toFixed(3);
+        rep.percent = percent.toFixed(4);
 
         return rep;
       });


### PR DESCRIPTION
This PR updates the total supply and fixes the calculated weight percentages of tribes/representatives, so it matches the percentage on https://tribes.paw.digital/. I also increased the number of decimals to four, to match the format of the Tribes site.

