### PR TITLE
Add option to change pawnimal icon for an account

### DIFF
--- a/src/app/components/account-details/account-details.component.css
+++ b/src/app/components/account-details/account-details.component.css
@@ -259,3 +259,6 @@
         height: auto;
     }
 }
+.change-pawnimal-icon-container {
+  margin: 30%;
+}

--- a/src/app/components/account-details/account-details.component.html
+++ b/src/app/components/account-details/account-details.component.html
@@ -60,7 +60,7 @@
 
         <div uk-grid>
 
-          <app-nano-identicon scale="12" [accountID]="accountID" [settingIdenticonsStyle]="settings.settings.identiconsStyle" class="nano-identicon" *ngIf="(settings.settings.identiconsStyle !== 'none')"></app-nano-identicon>
+          <app-nano-identicon scale="12" [accountID]="accountID"(click)="openChangePawnimalModal()"  [settingIdenticonsStyle]="settings.settings.identiconsStyle" class="nano-identicon" *ngIf="(settings.settings.identiconsStyle !== 'none')"></app-nano-identicon>
 
           <div class="uk-width-1-1 uk-width-expand@s">
 
@@ -743,6 +743,37 @@
         >
           <span class="icon icon-leave" uk-icon="icon: sign-out; ratio: 1.4;"></span>
           <span>Select a different account</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div id="change-pawnimal-modal" uk-modal>
+  <div class="uk-modal-dialog">
+    <div class="uk-modal-body">
+      <div class="uk-width-1-1">
+        <h3 class="menu-header">
+          Change Pawnimal
+        </h3>
+        <hr>
+        <div class="menu-option" (click)="previousPawnimalNonce()">
+          <span>Up</span>
+        </div>
+        <div>
+          <div class="uk-width-1-1 uk-margin-auto uk-margin-auto-vertical">
+            <div class="change-pawnimal-icon-container">
+              <app-nano-identicon scale="12" [nonce]="pawnimalIconNonce" [accountID]="accountID" [settingIdenticonsStyle]="settings.settings.identiconsStyle" class="nano-identicon" *ngIf="(settings.settings.identiconsStyle !== 'none')"></app-nano-identicon>
+            </div>
+          </div>
+        </div>
+        <div class="menu-option" (click)="nextPawnimalNonce()">
+          <span>Down</span>
+        </div>
+        <div class="menu-option" (click)="setPawnimalIcon()">
+          <span *ngIf="settingPawnimalIcon" class="spinner" uk-spinner="ratio: 0.5;"></span>
+          <span *ngIf="settingPawnimalIcon"> &nbsp; </span>
+          <span>I want this one</span>
         </div>
       </div>
     </div>

--- a/src/app/components/helpers/nano-identicon/nano-identicon.component.html
+++ b/src/app/components/helpers/nano-identicon/nano-identicon.component.html
@@ -2,7 +2,7 @@
 	<div #canvasContainer class="canvas-container"></div>
 </ng-container>
 <ng-container *ngIf="(settingIdenticonsStyle === 'natricon')">
-	<img class="natricon" [src]="('https://pawnimal.paw.digital/api/v1/nano?address=' + accountID)" (error)="imageLoadErrorOccurred = true" *ngIf="!imageLoadErrorOccurred">
+	<img class="natricon" [src]="('https://pawnimal.paw.digital/api/v1/nano?address=' + accountID + nonceUrlAddition)" (error)="imageLoadErrorOccurred = true" *ngIf="!imageLoadErrorOccurred">
 	<div class="natricon-placeholder" *ngIf="imageLoadErrorOccurred">
 		<img src="assets/img/natricon-placeholder.svg">
 	</div>

--- a/src/app/components/helpers/nano-identicon/nano-identicon.component.ts
+++ b/src/app/components/helpers/nano-identicon/nano-identicon.component.ts
@@ -11,9 +11,11 @@ export class NanoIdenticonComponent implements OnChanges, AfterViewInit {
   @Input() accountID: string;
   @Input() scale: number;
   @Input() settingIdenticonsStyle: string;
+  @Input() nonce: number;
 
   renderedIdenticon = '';
   imageLoadErrorOccurred = false;
+  nonceUrlAddition = '';
 
   constructor() { }
 
@@ -28,6 +30,10 @@ export class NanoIdenticonComponent implements OnChanges, AfterViewInit {
   }
 
   renderNanoidenticon() {
+    if (this.nonce !== undefined) {
+      this.nonceUrlAddition = '&nonce=' + this.nonce;
+    }
+
     if (
           (this.canvasContainer == null)
         || (this.settingIdenticonsStyle !== 'nanoidenticons')


### PR DESCRIPTION
How to use:
- Go to account
- On mobile click the 3 dots and go view account details
- Click the pawnimal icon
- Use the Up / Down buttons to choose something
- Click the "I choose this one" button to choose it
- Wait for the transaction to finish

Code parts:
- nano-identicon now has a nonce option to show an icon with specific nonce
- account details component has the logic to change the identicon
- logic in place that reloads the icon 5 seconds after the transaction