### PR TITLE
Colors 1.4.1 is not available; Rollback to 1.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9391,8 +9391,8 @@
         },
         "colors": {
           "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.1.tgz",
-          "integrity": "sha512-urbBmMVnD1vk0mUwCpnWv06P3f16EF+RMTtIXTkylJk5mAdfrMepu9B3hhSnL8DGkc1Ra6pENJHrXTKvcAZ0wA==",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+          "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
           "dev": true
         },
         "glob": {


### PR DESCRIPTION
npm install does not work right now because Colors 1.4.1 is not available anymore. The maintainer broke the package in 1.4.1 and this version was removed and is therefore not available anymore. By changing the lockfile with 1.4.0 npm install just works again.